### PR TITLE
Cellranger references defined with getGenomeAttribute

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -20,6 +20,13 @@
 params.fasta            = getGenomeAttribute('fasta')
 params.gtf              = getGenomeAttribute('gtf')
 params.star_index       = getGenomeAttribute('star')
+if (params.aligner == "cellrangerarc") {
+   params.cellranger_index = getGenomeAttribute('cellranger_atac')
+} else {
+   params.cellranger_index = getGenomeAttribute('cellranger')
+}
+params.cellranger_vdj_index = getGenomeAttribute('cellranger_vdj')
+
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,12 +45,10 @@ params {
 
     // Cellranger parameters
     skip_cellranger_renaming = false
-    cellranger_index         = null
 
     // Cellranger ARC parameters
     motifs                  = null
     cellrangerarc_config    = null
-    cellrangerarc_reference = null
     blacklist_path          = null
 
     // Emptydrops parameters
@@ -60,7 +58,6 @@ params {
     skip_doublets           = false
 
     // CellrangerMulti parameters
-    cellranger_vdj_index          = null
     skip_cellrangermulti_vdjref   = false // skip mkvdjref if not using VDJ data in cellranger/multi samplesheet
     gex_frna_probe_set            = null
     gex_target_panel              = null


### PR DESCRIPTION
These changes are required to use our internal genome reference repository,
to define the three cellranger indices (gex, vdj and atac) from the dictionary defined
in the configuration (iGenomes-style).


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
